### PR TITLE
donate: merge membership and one-time bullets

### DIFF
--- a/pages/donate.py
+++ b/pages/donate.py
@@ -40,15 +40,13 @@ support is very much appreciated.
 
 You have several options:
 
-* You can become a Freenet project "member" for a **recurring payment** of $5 or
-more per month. The advantage of this is that it gives the project a more stable
-and dependable income which makes it easier to make long term commitments to
-potential developers - right now it is often difficult to say whether we will be
-able to pay a developer the following month although so-far we have been
-fortunate.
+* You can donate using PayPal. You can become a Freenet project "member" for a
+recurring payment of $5 or more per month. This helps give the project a
+more stable and dependable income which makes it easier to make long-term
+commitments to potential developers. Right now it is often difficult to say
+whether we will be able to pay a developer the following month.
 You can become a member by signing up for a monthly recurring donation below (this requires a [PayPal][url_paypal] account).
-
-* You can *donate once* via PayPal by using the form below.
+Alternatively you can make a one-time donation.
 """) + "\n\n" + """
 [url_paypal]: https://www.paypal.com/
 """) + """


### PR DESCRIPTION
The donation forms are now side-by-side, which looks better, but the
membership bullet point referred to a form which was part of the
following bullet point.

This also removes the mention of "so far we have been fortunate" to
always be able to pay developers because it is no longer true.

"recurring payment" and "one-time" are no longer emphasized.
