### PR TITLE
Reduce margin between menu items to prevent early wrapping on Gecko browsers

### DIFF
--- a/assets/css/style-freenet-4.css
+++ b/assets/css/style-freenet-4.css
@@ -166,7 +166,7 @@ padding-bottom: 1px; /* to make space for the blue activation line */
 
 .navbar-inverse .navbar-nav-page > li > a {
 font-size: 13px;
-margin: 10px 20px 10px 20px;
+margin: 10px 18.9px 10px 18.9px;
 }
 
 .navbar-inverse .navbar-nav-language > li > a {


### PR DESCRIPTION
This makes a tiny adjustment to the spacing of menu items, which prevents the menu from wrapping differently on Gecko and Webkit based browsers. The change is visually imperceptible to me, but it is a bit of a hack.
