### PR TITLE
Change first row padding across all pages

### DIFF
--- a/assets/css/style-freenet-4.css
+++ b/assets/css/style-freenet-4.css
@@ -269,6 +269,19 @@ margin: 25px 20px;
   }
 }
 
+/* Padding to ensure first row isn't hidden by the navigation bar */
+@media screen and (min-width: 767px) and (max-width: 992px) {
+  .row:first-of-type {
+	  padding-top: 6em;
+  }
+}
+
+@media screen and (min-width : 992px) and (max-width: 1200px) {
+  .row:first-of-type {
+	  padding-top: 3em;
+  }
+}
+
 /*Progress Bars from CSS-tricks.
 
 - https://css-tricks.com/css3-progress-bars/


### PR DESCRIPTION
Currently, at horizontal resolutions between 992px and 1200px the Download, About, Documentation, Help, Donate, and Contribute pages all have their headings covered by the menu bar. This affects both Chromium and Firefox, though it's worse on Firefox due to the menu bar bug resolved in #13 . This PR resolves this issue. Note it makes the index's padding larger, however. #12 includes a change addressing this 791fce1, and I could rebase it here if need be.
