### PR TITLE
Prevent Menu from Overlapping Content

### DIFF
--- a/assets/css/style-freenet-4.css
+++ b/assets/css/style-freenet-4.css
@@ -269,6 +269,19 @@ margin: 25px 20px;
   }
 }
 
+/* Padding to ensure first row isn't hidden by the navigation bar */
+@media screen and (min-width: 767px) and (max-width: 992px) {
+  body {
+	  padding-top: 6em;
+  }
+}
+
+@media screen and (min-width : 992px) and (max-width: 1200px) {
+  body {
+	  padding-top: 3em;
+  }
+}
+
 /*Progress Bars from CSS-tricks.
 
 - https://css-tricks.com/css3-progress-bars/

--- a/assets/css/style-freenet-4.css
+++ b/assets/css/style-freenet-4.css
@@ -213,7 +213,6 @@ HOME SECTION STYLES
 
 #home {
 text-align: center;
-padding-top: 120px;
 padding-bottom: 60px;
 }
 


### PR DESCRIPTION
Currently, at horizontal resolutions between 992px and 1200px the Download, About, Documentation, Help, Donate, and Contribute pages all have their headings covered by the menu bar. This affects both Chromium and Firefox, though it's worse on Firefox due to the menu bar bug. The issue is not entirely resolved on Firefox for this reason, however. This is a corrected version of #14 .
