### PR TITLE
Replace "corporation" with "organization"

### DIFF
--- a/pages/donate.py
+++ b/pages/donate.py
@@ -201,8 +201,7 @@ Send your donations to {bitcoin_address}.
 """).format(donate_email=donate_email, bitcoin_address=bitcoin_address) + "\n\n" + _("""
 ## How can I be sure that my donation will be used appropriately?
 
-All donations go to The Freenet Project Inc, a non-profit 501c3 organization with
-the following mission statement:
+All donations go to The Freenet Project Inc, a non-profit 501(c)(3) organization with the following mission statement:
 
 > The specific purpose of this corporation is to assist in developing and
 > disseminating technological solutions to further the open and democratic

--- a/pages/donate.py
+++ b/pages/donate.py
@@ -201,7 +201,7 @@ Send your donations to {bitcoin_address}.
 """).format(donate_email=donate_email, bitcoin_address=bitcoin_address) + "\n\n" + _("""
 ## How can I be sure that my donation will be used appropriately?
 
-All donations go to The Freenet Project Inc, a non-profit 501c3 corporation with
+All donations go to The Freenet Project Inc, a non-profit 501c3 organization with
 the following mission statement:
 
 > The specific purpose of this corporation is to assist in developing and

--- a/pages/donate.py
+++ b/pages/donate.py
@@ -201,7 +201,7 @@ Send your donations to {bitcoin_address}.
 """).format(donate_email=donate_email, bitcoin_address=bitcoin_address) + "\n\n" + _("""
 ## How can I be sure that my donation will be used appropriately?
 
-All donations go to The Freenet Project Inc, a non-profit 501(c)(3) organization with the following mission statement:
+All donations go to The Freenet Project Incorporated, a non-profit 501(c)(3) organization with the following mission statement:
 
 > The specific purpose of this corporation is to assist in developing and
 > disseminating technological solutions to further the open and democratic

--- a/pages/index.py
+++ b/pages/index.py
@@ -125,7 +125,7 @@ We are raising funds so we can continue paying our developer for another year.
         """))
         donate_button_text = _("Donate!")
         donation_target = "27500"
-        nonprofit = _("The Freenet Project Inc is a non-profit 501(c)(3) corporation.")
+        nonprofit = _("The Freenet Project Inc is a non-profit 501(c)(3) organization.")
         return substitute_html(content,
             html__sliders=concat_html(sliders),
             str__tagline=tagline,


### PR DESCRIPTION
"Corporation" can imply "corporate" and "stuffy" and "rich"; FPI is none
of these. "Organization" is a valid way to refer to a 501(c)(3); the IRS
does it. [0]

[0] https://www.irs.gov/Charities-&-Non-Profits/Charitable-Organizations/Exemption-Requirements-Section-501(c)(3)-Organizations
