### PR TITLE
faq: add entry on users facing legal trouble

### DIFF
--- a/pages/help.py
+++ b/pages/help.py
@@ -957,7 +957,7 @@ If you are concerned about governments, you should use Freenet's capacity to con
 
 While we applaud law enforcement's apparent success in apprehending suspects allegedly sharing child abuse images, any security flaws they may have used are not limited to such noble usage.
 Many governments persecute and prosecute political dissidents for legitimate speech published online.
-Therefore we hope to discover and fix these flaws to protect legitimate users.
+Therefore we hope to discover and fix these flaws to protect those who fight for human rights, against corruption, for a peaceful future, and for other legitimate goals.
 """) + """
 
 [f]: http://www.thedickinsonpress.com/news/north-dakota/3885239-predators-police-online-struggle

--- a/pages/help.py
+++ b/pages/help.py
@@ -952,6 +952,7 @@ _("""
 Yes.
 There is one such instance that we know of.
 United States law enforcement can identify anonymous users of [Freenet][f] and [Tor][t].
+Without further information we do not know how they did this, but we suspect it affects people using "normal" or lower network security level.
 It is reasonable to assume that other governments have access to the same technology, which is provided by private contractors.
 If you are concerned about governments, you should use Freenet's capacity to connect only to users you trust, ("high" network security level or higher) and bear in mind that no anonymity technology provides perfect protection.
 

--- a/pages/help.py
+++ b/pages/help.py
@@ -947,6 +947,22 @@ We believe our installer is not infected with malicious software, and if you are
 [url_smartscreen]: http://windows.microsoft.com/en-us/windows7/smartscreen-filter-frequently-asked-questions-ie9
 [url_installer]: https://github.com/freenet/wininstaller-innosetup
 """),
+                    FaqItem("legal-trouble", _("Has anyone ever faced legal trouble for their anonymous activities conducted on Freenet?"),
+_("""
+Yes.
+There is one such instance that we know of.
+United States law enforcement can identify anonymous users of [Freenet][f] and [Tor][t].
+It is reasonable to assume that other governments have access to the same technology, which is provided by private contractors.
+If you are concerned about governments, you should use Freenet's capacity to connect only to users you trust, ("high" network security level or higher) and bear in mind that no anonymity technology provides perfect protection.
+
+While we applaud law enforcement's apparent success in apprehending suspects allegedly sharing child abuse images, any security flaws they may have used are not limited to such noble usage.
+Many governments persecute and prosecute political dissidents for legitimate speech published online.
+Therefore we hope to discover and fix these flaws to protect legitimate users.
+""") + """
+
+[f]: http://www.thedickinsonpress.com/news/north-dakota/3885239-predators-police-online-struggle
+[t]: http://motherboard.vice.com/read/court-docs-show-a-university-helped-fbi-bust-silk-road-2-child-porn-suspects
+"""),
                 ]),
             ]
         table_of_contents = concat_html([x.generate_index() for x in subsections])


### PR DESCRIPTION
As suggested by Matthew: https://emu.freenetproject.org/pipermail/devl/2015-November/038639.html

The entry reads:

> ### Has anyone ever faced legal trouble for their anonymous activities conducted on Freenet?
> 
> Yes. There is one such instance that we know of. United States law enforcement can identify anonymous users of [Freenet](http://www.thedickinsonpress.com/news/north-dakota/3885239-predators-police-online-struggle) and [Tor](http://motherboard.vice.com/read/court-docs-show-a-university-helped-fbi-bust-silk-road-2-child-porn-suspects). It is reasonable to assume that other governments have access to the same technology, which is provided by private contractors. If you are concerned about governments, you should use Freenet's capacity to connect only to users you trust, ("high" network security level or higher) and bear in mind that no anonymity technology provides perfect protection.
> 
> While we applaud law enforcement's apparent success in apprehending suspects allegedly sharing child abuse images, any security flaws they may have used are not limited to such noble usage. Many governments persecute and prosecute political dissidents for legitimate speech published online. Therefore we hope to discover and fix these flaws to protect legitimate users.
