### PR TITLE
documentation: remove Freemailv1 and Frost section. Replaced with a link to the fsng for now.

### DIFF
--- a/pages/documentation.py
+++ b/pages/documentation.py
@@ -27,12 +27,8 @@ department.
 *   [**Understand**](#understand)
      Explains the workings of Freenet, and a glossary with the most frequently
      used terms.
-*   [**Freemail**](#freemail)
-     How to setup Freenet's own anonymous email service.
-*   [**Frost**](#frost)
-     Frost is the oldest and most used messaging and file sharing tool in the
-     Freenet suite. This describes how to set it up and use it for the first
-     time.
+*   [**Social**](#social)
+     How to setup E-Mail, Forums and Microblogging over Freenet.
 *   [**jSite**](#jsite)
      jSite is a Freenet website (a.k.a. Freesite) insertion tool.
 *   [**Wiki**](https://wiki.freenetproject.org/)
@@ -604,294 +600,19 @@ to know much about manifests in order to use Freenet, since it is a part that
 is handled internally.
 """)))
 
-class FreemailSection(Section):
+class SocialSection(Section):
     def __init__(self):
-        self.slug = "freemail"
-        self.title = _("Freemail")
+        self.slug = "social"
+        self.title = _("Social")
     def get_content(self):
         # License: GFDL (from old freenetproject.org website)
         return text(md(_("""
-Freemail is an email system for Freenet. It allows you to send anonymous
-emails to other Freenet users using your standard email client. It is
-currently not bundled in the Freenet installer, and has to be downloaded
-separately. You can also try the Freemail plugin by selecting it from the
-list on the plugins page of your Freenet node. Beware, though, that the
-plugin is still in an early stage of development, and users should be active
-about looking in log files and reporting problems if they find them.
-
-You can download the latest pre-compiled version from
-[https://downloads.freenetproject.org/alpha/plugins/Freemail/](https://downloads.freenetproject.org/alpha/plugins/Freemail/)
-""") + "\n\n" + _("""
-### Easy account setup
-
-The easy way to set up a Freemail account is to visit the Freemail plugin,
-after you have downloaded it, through your **Plugins** web page. The web
-interface will prompt you for an IMAP name, an IMAP password, and a Freemail
-shortname to associate with the account. When the account is created, it will
-email you the secure name that it generated for you.
-
-The chosen short Freemail-address must be unique and will give you an address
-looking like:
-
-*   <anything>@<short-Freemail-address>.freemail
-
-The <anything> before the @ will be ignored. It is only there because mail
-user and transport agents want to see an @ in addresses. Yes, we _do_ know
-this is an ugly kludge.
-
-Once you have installed the freemail plugin for your Freenet proxy daemon,
-starting or restarting the daemon will start the freemail service for you
-automatically.
-
-If for some reason you cannot make the web interface work, we have included
-hand-configuration instructions down this page.
-""") + "\n\n" + _("""
-### Mail client setup
-
-Now you have the Freemail proxy running, which means that you can send and
-receive emails through Freenet. For this we recommend that you set up your
-favorite email client to use the special Freenet private ports:
-
-*   **Incoming emails** - Protocol: **IMAP**, Server: **localhost**, Port: **3143**
-*   **Outgoing emails** - Protocol: **SMTP**, Server: **localhost**, Port: **3025**
-
-Your Freemail plugin must be running while you are reading and sending
-freemails. Leaving your node running, with the Freemail pugin enabled,
-will ensure this. For debugging purposes, it is also possible to send and
-receive Freemail mail with only the Freenet jar running.
-""") + "\n\n" + _("""
-### Fetching Freemail mail with fetchmail
-
-You can easily make [fetchmail](http://fetchmail.berlios.de/) poll your
-freenet mail with an entry like this:
-
-<pre>	poll freenet via localhost with proto imap port 3143
-	user LOCALNAME here is IMAPNAME there with password PASSWORD</pre>
-
-This will cause Freemail mail to be automatically fetched and merged into
-your normal incoming mail stream, so any of your email clients will see it.
-Of course, you will need to change IMAPNAME and PASSWORD to match the
-authetication pair you gave when you created the Freemail account,
-and LOCALNAME to the local login you want to receive the mail.
-
-A variant of this recipe will still work if you have your freenet node.
-running on another machine. Just change "localhost" to the DNS address of the
-node host.
-""") + "\n\n" + _("""
-### Thunderbird
-
-If you use Thunderbird as your email client:
-
-1. From the Edit menu, select Account Settings.
-2. Click the Add Account... button.
-3. Select Email Account and click Next.
-4. Type in the name and either the long Freemail address you were given, or
-   your short address if you created one. Check this carefully as an incorrect
-   address here will not only mean people won't be able to reply to you,
-   but your messages will appear as 'Spoofed'. Once you've done this,
-   click Next.
-5. Set the type of incoming server to IMAP and the incoming server name to
-   localhost. Then click Next.
-6. For the Incoming User Name, use the account name you chose earlier ('john' in
-   this example), which may not be the same as your email address. Click Next.
-7. Enter an arbitrary Account Name and click Next and then Finish.
-8. Now we have to change the IMAP port number from the default: On the left
-   panel click on Server Settings under the new account. Change the Port to
-   3143 from the default of 143.
-
-Now you should be able to read incoming freemails. To send out emails:
-
-1. From the Edit menu, select Account Settings.
-2. In the left-hand panel, scroll down and click on the Outgoing Server (SMTP)
-   option.
-3. You probably already have at least one SMTP server set up already for your
-   normal emails. So click on the Add... button to create one specially for
-   freemails.
-4. Under Description put anything you want - Freemail might be a good choice.
-   Set Server Name to localhost and change Port to 3025\. Make sure 'Use name
-   and password' is checked and put your original account name as the User
-   Name ('john' in our example). 'Use secure connection' should be set to No
-   (don't worry, it's only the local connection that is unencrypted). Click OK.
-5. The final thing is to set your new Freemail account to use this outgoing
-   server instead of the default one. So in the left panel find and click on
-   the top line of the new incoming mail account you added. In our example
-   this would be something like me@jsmith.freemail. There should be a
-   drop-down box called Outgoing Server (SMTP). Set this to the new setup we
-   just added: something like Freemail - localhost. And click OK.
-
-Congratulations - you're now set up to send and receive email over Freenet!
-""") + "\n\n" + _("""
-### Hand configuration
-
-To set up an account for Freemail by hand, execute the following commands:
-
-<pre>	java -jar Freemail.jar --newaccount <username>
-	java -jar Freemail.jar --passwd <username> <password>
-	java -jar Freemail.jar --shortaddress <username> <short-Freemail-address>
-	java -jar Freemail.jar</pre>
-
-Exchange the values within <brackets> with the appropriate values.
-
-After running the last command you now have a running Freemail proxy,
-listening on localhost at IMAP port 3143 for incoming mails, and SMTP port
-3025 for outgoing mails. Connect to it using your favourite email client
-software.
-""") + "\n\n" + _("""
-If you didn't follow, here's a longer and more detailed recipe:
-
-### Account Setup
-
-Change to the directory containing the Freemail.jar file. At the command
-line, type:
-
-<pre>	java -jar Freemail.jar</pre>
-""") + "\n\n" + _("""
-If you are running Freemail for the first time, it will prompt you to create
-an account:
-
-<pre>	Starting Freemail for the first time.
-	You will probably want to add an account by running Freemail with arguments --newaccount <username></pre>
-
-So do what it says. The username you create here is used to authenticate to
-the Freemail-service and will only be seen by you, it isn't part of your
-freemail address:
-
-<pre>	java -jar Freemail.jar --newaccount john</pre>
-
-It now generates your Freemail address which is a long random string like
-**anything@DS3FG3R...SF6FHJ8YUK.freemail**. Generating the cryptographic
-keypair is a computation-intensive process and may take a few minutes on a
-slow machine.
-
-<pre>	Generating mailsite keys...
-	Mailsite keys generated.
-	Your Freemail address is: anything@DS3FG3R...SF6FHJ8YUK.freemail
-	Generating cryptographic keypair (this could take a few minutes)...
-	Account creation completed.
-	Account created for john. You may now set a password with --passwd <password></pre>
-""") + "\n\n" + _("""
-The next step is to create a password for your account. The syntax to create
-a password is shown below:
-
-<pre>	java -jar Freemail.jar --passwd <username> <password></pre>
-
-To create the password **secretpass** for the user **john**, type:
-
-<pre>	java -jar Freemail.jar --passwd john secretpass</pre>
-
-Now we have an account, a password for that account and a rather lengthy
-Freemail-address. The problem is that not many people in the world will be
-able to remember that Freemail-address. The solution to this problem is to
-create a short address that points to the long one:
-
-To do this, run the main command again:
-
-<pre>	java -jar Freemail.jar</pre>
-
-and the software will prompt you to create a short Freemail address:
-
-<pre>	Secure Freemail address: anything@DS3FG3R...SF6FHJ8YUK.freemail
-	You don't have a short Freemail address. You could get one by running Freemail
-	with the --shortaddress option, followed by your account name and the name
-	you'd like. For example, 'java -jar freemail.jar --shortaddress bob bob' will give
-	you the address 'anything@bob.freemail'. Try to pick something unique!
-	trying slotinsert to freenet:SSK@sdfgsdfg...ertretert/mailsite-1/mailpage</pre>
-""") + "\n\n" + _("""
-The syntax to create a short freemail address is:
-
-<pre>	java -jar Freemail.jar --shortaddress <username> <short address></pre>
-
-To create an alias known as **jsmith** for user **john**, write:
-
-<pre>	java -jar Freemail.jar --shortaddress john jsmith</pre>
-
-If that short alias is free, it will tell you your Freemail address:
-
-<pre>	Secure Freemail address: anything@DS3FG3R...SF6FHJ8YUK.freemail
-	Short Freemail address (*probably* secure): anything@jsmith.freemail</pre>
-
-Now you have created a Freemail account, a long and a short address and set
-up a password for the account. Now, all you need to do is to start the
-Freemail proxy, to listen for incoming IMAP and SMTP connections. The
-Freemail proxy must run while you use Freemail, or else no mails you send
-will get delivered. To start the server, run the command:
-
-<pre>	java -jar Freemail.jar</pre>
-""") + "\n\n" + _("""
-### Troubleshooting tips
-
-If you try to run the Freemail jar and get messages that look like the following:
-
-<pre>	24/12/2008 11:20:52 ERROR(freemail.smtp.SMTPListener): Error in SMTP server - Address already in use
-	24/12/2008 11:20:52 ERROR(freemail.imap.IMAPListener): Error in IMAP server - Address already in use</pre>
-
-...it probably means you downloaded the Freemail plugin through the Web
-interface and your node is already running it. On a GNU/Linux machine you can
-check to see if the private SMTP and IMAP ports are actually in use with
-`netstat -tln`; the port numbers you're looking for in the listing are 3143 (
-Freenet IMAP) and 3025 (Freenet SMTP).
-
-If you get these messages and these ports are _not_ in use, try shutting down
-and restarting the node. If the problem persists after that, you have found a
-bug and should file it with the Freenet developers.
-
-If the ports are indeed in use, check the **List of Plugins** on your
-**Plugins**. If Freemail is in that list, then you can eaither unload it and
-go through the manual procedure (running java -jar Freemail.jar) or configure
-your Freemail account through the web interface.
-""")))
-
-class FrostSection(Section):
-    def __init__(self):
-        self.slug = "frost"
-        self.title = _("Frost")
-    def get_content(self):
-        # License: GFDL (from old freenetproject.org website)
-        return text(md(_("""
-Frost provides message boards with filesharing.
-
-To run Frost on GNU/Linux or POSIX from the command line, change to your
-Freenet install directory, then change to the frost subdirectory. Then make
-the frost.sh file executable, and run it:
-
-<pre>	cd /home/username/
-	cd frost/
-	chmod +x ./frost.sh
-	./frost.sh</pre>
-""") + "\n\n" + _("""
-The first time you start Frost, you will get a number of dialogs. The first
-ask you if you would like to import old Frost data. If this is the first time
-you use Freenet at all, you can safely answer **Clean startup** here.
-
-![](assets/img/frost/clean-start.png)
-
-Since Freenet is able to run on both Freenet 0.5 and the current Freenet 0.7,
-you will need to specify which version you want to run with. If you have
-followed the previous install instructions, you will probably want **Freenet
-0.7 (Darknet)**.
-
-![](assets/img/frost/select-version.png)
-
-Next step is to choose which identidy you want to be known by when using
-Frost. As it says, it does not have to be unique, but it certainly helps.
-
-![](assets/img/frost/choose-identity.png)
-
-You will then get the main Frost window, where one can participate in the
-message boards and up/download files. The windows will probably take a while
-to populate on the first startup.
-
-![](assets/img/frost/main-window.png)
-""") + "\n\n" + _("""
-### Sharing files
-
-Sharing files can be done by clicking the **Shared files** -tab and then
-clicking on the Folder-icon top left in the appearing tab.
-""") + "\n\n" + _("""
-### Further information
-
-Additional information about Frost can be found in the mailing-list or on the
-official website: [Frost Homepage](http://jtcfrost.sourceforge.net/)
+Freenet provides the foundation for anonymous E-Mail, Forums and Chat,
+as well as a replacement for Facebook/Twitter. Setup of these is
+described in the
+[Freenet Social Networking Guide](http://freesocial.draketo.de/)
+which can also be accessed
+[over Freenet](http://127.0.0.1:8888/USK@t5zaONbYd5DvGNNSokVnDCdrIEytn9U5SSD~pYF0RTE,guWyS9aCMcywU5PFBrKsMiXs7LzwKfQlGSRi17fpffc,AQACAAE/fsng/58/).
 """)))
 
 class JSiteSection(Section):
@@ -1003,8 +724,7 @@ class DocumentationPage(Page):
             ConnectSection(),
             ContentSection(),
             UnderstandSection(),
-            FreemailSection(),
-            FrostSection(),
+            SocialSection(),
             JSiteSection(),
             WikiSection()
             ]

--- a/pages/documentation.py
+++ b/pages/documentation.py
@@ -28,7 +28,7 @@ department.
      Explains the workings of Freenet, and a glossary with the most frequently
      used terms.
 *   [**Social**](#social)
-     How to setup E-Mail, Forums and Microblogging over Freenet.
+     How to setup email, forums and microblogging over Freenet.
 *   [**jSite**](#jsite)
      jSite is a Freenet website (a.k.a. Freesite) insertion tool.
 *   [**Wiki**](https://wiki.freenetproject.org/)
@@ -607,7 +607,7 @@ class SocialSection(Section):
     def get_content(self):
         # License: GFDL (from old freenetproject.org website)
         return text(md(_("""
-Freenet provides the foundation for anonymous E-Mail, Forums and Chat,
+Freenet provides the foundation for anonymous email, forums and chat,
 as well as a replacement for Facebook/Twitter. Setup of these is
 described in the
 [Freenet Social Networking Guide](http://freesocial.draketo.de/)


### PR DESCRIPTION
These were completely outdated and misleading.

No wonder people came into the chat asking for Frost: Those were the ones who actually read our documentation!
