### PR TITLE
Update mac installer link for 2.0.4/1473

### DIFF
--- a/pages/download.py
+++ b/pages/download.py
@@ -73,7 +73,7 @@ def run_show_hide_script():
                 download('assets/jnlp/FreenetInstaller.exe');
             }
             if (OSName == "macos") {
-                download('https://github.com/freenet/mactray/releases/download/v2.0.3/FreenetTray_2.0.3.zip');
+                download('https://github.com/freenet/mactray/releases/download/v2.0.4/FreenetTray_2.0.4.zip');
             }
             if (OSName == "unix") {
                 download('assets/jnlp/freenet.jnlp');
@@ -133,8 +133,8 @@ When done, your default browser will automatically open up to Freenet's web-base
 
 Freenet requires OS X 10.8 or later.
 """) + "\n\n" + """
-[url_mac_installer]: https://github.com/freenet/mactray/releases/download/v2.0.3/FreenetTray_2.0.3.zip
-[url_gpg_sig]: https://downloads.freenetproject.org/alpha/mactray/FreenetTray_2.0.3.zip.sig
+[url_mac_installer]: https://github.com/freenet/mactray/releases/download/v2.0.4/FreenetTray_2.0.4.zip
+[url_gpg_sig]: https://downloads.freenetproject.org/alpha/mactray/FreenetTray_2.0.4.zip.sig
 """))+div("unix",md(_("""
 ### GNU/Linux & POSIX
 


### PR DESCRIPTION
Note: depends on `.sig` file at Github:

`https://github.com/freenet/mactray/releases/download/v2.0.4/FreenetTray_2.0.4.zip.sig`

being pushed to: 

`https://downloads.freenetproject.org/alpha/mactray/FreenetTray_2.0.4.zip.sig`
