### PR TITLE
Homepage: Remove SUMA badge

### DIFF
--- a/assets/css/style-freenet.css
+++ b/assets/css/style-freenet.css
@@ -726,6 +726,19 @@ color: rgb(40, 141, 203);
 }
 
 
+/*============================
+NEWS SECTION STYLES
+==============================*/
+#news .news-wrapper {
+background-color:rgba(255, 255, 255, 0.1);
+padding: 20px;
+border-radius: 5px;
+-moz-border-radius: 5px;
+-webkit-border-radius: 5px;
+margin-bottom: 40px;
+min-height:200px;
+}
+
 
 /*============================
 CONTACT SECTION STYLES

--- a/assets/css/style-freenet.css
+++ b/assets/css/style-freenet.css
@@ -286,14 +286,6 @@ margin-left: 20px;
 margin-right: 20px;
 }
 
-/*Hide Suma-award notice on small screens*/
-@media screen and (max-width: 767px) {
-  #suma_award_notice {
-          visibility: hidden;
-          height: 0px;
-  }
-}
-
 /*Main Logo*/
 #home-logo {
     margin-top: 2em;

--- a/assets/css/style-freenet.css
+++ b/assets/css/style-freenet.css
@@ -300,6 +300,10 @@ margin-right: 20px;
     margin-bottom: 1em;
 }
 
+#home-logo > img {
+    max-width: 90%;
+}
+
 #home-download {
     margin-top: 1em;
     margin-bottom: 2em;

--- a/pages/index.py
+++ b/pages/index.py
@@ -55,8 +55,8 @@ Leap over censorship<br>
 Escape total surveillance
 """))
         mission = md(_("""
-Freenet re-establishes freedom of speech on the Internet.<br>
-Install Freenet and join the peer-to-peer network today!
+Freenet is a peer-to-peer platform for censorship-resistant communication and publishing.
+Browse websites, post on forums, and publish files within Freenet with strong privacy protections.
 """))
         download_text = _("Download Freenet")
         read_more = """<a href="{}" class="readmore">""" + _("""read more…""") + """</a>"""

--- a/pages/index.py
+++ b/pages/index.py
@@ -131,9 +131,6 @@ class ServiceSection(Section):
         content = """
 <!-- service start -->
 <div class="row">
-    <div class="col-sm-12 col-md-12 col-lg-12" style="text-align: center">
-        $md__whatis_text
-    </div>
     $html__services
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12" style="text-align: center">
         <div class="download">
@@ -150,7 +147,6 @@ class ServiceSection(Section):
         tagline = _("Share, Chat, Browse. Anonymously.")
         download_text = _("Download Freenet")
         return substitute_html(content,
-            md__whatis_text=md(_("Freenet is a peer-to-peer network for censorship-resistant communication.")),
             html__services=concat_html(services),
             str__tagline=tagline,
             str__download_text=download_text)

--- a/pages/index.py
+++ b/pages/index.py
@@ -157,11 +157,16 @@ class NewsSection(Section):
         self.title = _("Latest News")
     def get_content(self):
         # we show the most recent news items
+        content = """
+<div class="news-wrapper">
+$md__items
+</div>
+"""
         md_content = ""
         news_items = news.news_items()
         for item in news_items[:min(5, len(news_items))]:
             md_content += item.markdown_link() + "\n\n"
-        return text(md(md_content))
+        return substitute_html(content, md__items=md(md_content))
 
 class IndexPage(Page):
     def __init__(self):

--- a/pages/index.py
+++ b/pages/index.py
@@ -138,16 +138,6 @@ class ServiceSection(Section):
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12" style="text-align: center">
         <div class="download">
         <p>$str__tagline</p>
-        <!-- FIXME: become social
-        <div class="social">
-        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-facebook "></i></a>
-        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-twitter"></i></a>
-        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-google-plus "></i></a>
-        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-linkedin "></i></a>
-        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-pinterest "></i></a>
-        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-github "></i></a>
-        </div>
-        -->
         <a href="download.html#autostart" class=" btn button-custom btn-custom-two">
             <i class="icon ion-arrow-down-a"></i>
             $str__download_text

--- a/pages/index.py
+++ b/pages/index.py
@@ -41,11 +41,6 @@ class HomeSection(Section):
                 </div>
             </div>
         </div>
-                        <div class="social">
-                        <a href="https://twitter.com/freenetproject" class="btn button-custom btn-custom-one" ><i class="fa fa-twitter"></i></a>
-                        <a href="https://github.com/freenet/fred" class="btn button-custom btn-custom-one" ><i class="fa fa-github "></i></a>
-                        </div>
-
     </div>
 </section>
 <!--HOME SECTION END-->

--- a/pages/index.py
+++ b/pages/index.py
@@ -15,13 +15,7 @@ class HomeSection(Section):
 <section id="home">
     <div class="container">
         <div class="row text-center">
-            <div class="col-sm-2 col-md-2 col-lg-2 hidden-xs">
-                <div class="item active sidebar" id="suma_award_notice">
-                    <p><a href="news.html#20150211"><img src="assets/img/suma2015_badge_transparent_3.png" alt="SUMA Award 2014/15" /></a></p>
-                </div>
-            </div>
-
-            <div class="col-sm-8 col-md-8 col-lg-8">
+            <div class="col-sm-8 col-sm-offset-2 col-md-8 col-md-offset-2 col-lg-8 col-lg-offset-2">
                 <div class="row">
                     <div id="home-logo">
                         <img src="assets/img/rabbit/freenet-bunny-with-name-flying.png" alt="Freenet Logo, leap over censorship"/><br />

--- a/pages/index.py
+++ b/pages/index.py
@@ -108,30 +108,6 @@ If one percent of people used Freenet, everyone could safely be a whistleblower.
                 </div>
             </div>
         </div>
-        <div class="row">
-            <!--DONATE SUBSECTION -->
-            <div class="col-sm-12 col-md-12 col-lg-12">
-                <div class="item active donate" id="donate_button">
-                     $md__donate_text
-                     <div class="meter blue" id="donate_bar_small">
-                         <div class="quantity" style="left: 15px;">$$MONEYBALANCE</div>
-                         <div class="quantity" style="right: 15px;">$$$str__donation_target</div>
-                         <span style="width: 100%)">
-                         </span>
-                     </div>
-                     <script type="text/javascript">
-                         fund_percentage = (MONEYBALANCE / $str__donation_target);
-                         if(fund_percentage <= 1/3) {
-                             donate_bar = document.getElementById("donate_bar_small");
-                             donate_bar.className = "meter red";
-                         }
-                     </script>
-                     <a class="btn button-custom btn-custom-two donate-button" href="donate.html">$str__donate_button_text</a>
-                     <p id="donate_fineprint">$str__nonprofit $str__tax_deductable $str__503_read_more</p>
-                </div>
-            </div>
-            <!-- DONATE SUBSECTION END -->
-        </div>
                         <div class="social">
                         <a href="https://twitter.com/freenetproject" class="btn button-custom btn-custom-one" ><i class="fa fa-twitter"></i></a>
                         <a href="https://github.com/freenet/fred" class="btn button-custom btn-custom-one" ><i class="fa fa-github "></i></a>

--- a/pages/index.py
+++ b/pages/index.py
@@ -93,16 +93,6 @@ If one percent of people used Freenet, everyone could safely be a whistleblower.
                         $md__mission
                     </div>
                     <div id="home-download" class="download">
-                        <!-- FIXME: become social
-                        <div class="social">
-                        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-facebook "></i></a>
-                        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-twitter"></i></a>
-                        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-google-plus "></i></a>
-                        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-linkedin "></i></a>
-                        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-pinterest "></i></a>
-                        <a href="#" class="btn button-custom btn-custom-one" ><i class="fa fa-github "></i></a>
-                        </div>
-                        -->
                         <a href="download.html#autostart" class=" btn button-custom btn-custom-two">
                             <i class="icon ion-arrow-down-a"></i>
                             $str__download_text
@@ -142,6 +132,11 @@ If one percent of people used Freenet, everyone could safely be a whistleblower.
             </div>
             <!-- DONATE SUBSECTION END -->
         </div>
+                        <div class="social">
+                        <a href="https://twitter.com/freenetproject" class="btn button-custom btn-custom-one" ><i class="fa fa-twitter"></i></a>
+                        <a href="https://github.com/freenet/fred" class="btn button-custom btn-custom-one" ><i class="fa fa-github "></i></a>
+                        </div>
+
     </div>
 </section>
 <!--HOME SECTION END-->

--- a/pages/index.py
+++ b/pages/index.py
@@ -10,66 +10,6 @@ class HomeSection(Section):
         self.title = ""
 
     def generate(self):
-        def slider_item(title, text, active=""):
-            template = """
-    <div class="item $str__active">
-        <h3>$str__title</h3>
-        $md__text
-    </div>
-    """
-            return substitute_html(template,
-                str__title=title,
-                md__text=md(text),
-                str__active=active)
-
-        sliders = [
-            # Slider items copyright Gerard Krol, licensed GFDL/CC-BY-SA 4.0/GPLv2+
-            slider_item(_("Share, Chat, Browse. Anonymously."), _("""
-Freenet is a platform for censorship-resistant communication and publishing.
-It helps you to remain anonymous, and communicate without fear.
-""") + "\n\n" + """<span class="hidden-xs">""" + _("""
-*'Daddy, where were you when they took freedom of the press away from the Internet?'*
-— Mike Godwin ([read more](about.html))
-""") + """</span>""", "active"),
-            slider_item(_("Host a Website"), _("""
-Need a website nobody can take over? That is hosted for free? That is very
-resistant to attacks? Publish it on Freenet!
-""") + "\n\n" + """<br /><span class="hidden-xs hidden-sm">""" + _("""
-*'Now the Mempo repository can not be censored, DDoSed or taken offline, despite having just one tiny server.'* — rfree in [apt-get over Freenet](news.html#20150105)
-""") + """</span>"""),
-            slider_item(_("Share Files"), _("""
-Upload a file to Freenet and anyone with the secret URL can access it.
-""") + "\n\n" + _("""
-*[follow the blue rabbit
-through the looking glass](download.html#autostart)*
-""")),
-            slider_item(_("Meet New People"), _("""
-People from all over the world use Freenet to communicate. Some of them do so
-anonymously. You might never hear their voices in the open.
-""") + "\n\n" + """<span class="hidden-xs">""" + _("""
-*'The value of publishing is not me wanting you to watch. The value of publishing is you wanting to see what I provide.'* — A.B.
-""") + """</span>"""),
-            slider_item(_("Experiment with Exciting New Technology"), _("""
-Freenet is on the cutting edge of distributed routing research. The data
-storage provided by Freenet is a proving ground for a number of new
-distributed systems. ([Papers](about.html#papers))
-""") + "\n\n" + """<span class="hidden-xs hidden-sm">""" + _("""
-*'A decentralized anonymous datastore with real censorship resistance, no central authority and long lifetime only for information which people actually use.'* — [The forgotten Cryptopunk Paradise](http://draketo.de/english/freenet/forgotten-cryptopunk-paradise)
-""") + """</span>"""),
-            slider_item(_("Improve the World"), _("""
-By using Freenet from the "free world" you help people in oppressive regimes
-share information. The more people use Freenet the easier it will be to
-obtain.""") + "\n\n" + """<span class="hidden-xs hidden-sm">""" + _("""
-If one percent of people used Freenet, everyone could safely be a whistleblower.
-""") + """</span>"""),
-            slider_item(_("Join us in Freenet"), """<span class="visible-xs">""" + _("""
-*'Daddy, where were you when they took freedom of the press away from the Internet?'*
-— Mike Godwin ([read more](about.html))
-""") + """</span>""" + """<span class="hidden-xs">""" + _("""
-*'Many years passed, two towers fell, the empire expanded its hunt for rebels all over the globe, and now, as the empire’s grip has become so horrid that even the most loyal servants of the emperors turn and expose their dark secrets, Freenet is still moving forward.'*
-— [The forgotten Cryptopunk Paradise](http://draketo.de/english/freenet/forgotten-cryptopunk-paradise)
-""") + """</span>"""),
-        ]
         content = """
 <!--HOME SECTION START-->
 <section id="home">
@@ -97,13 +37,6 @@ If one percent of people used Freenet, everyone could safely be a whistleblower.
                             <i class="icon ion-arrow-down-a"></i>
                             $str__download_text
                         </a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div id="carousel-slider">
-                        <div class="carousel-inner">
-                            $html__sliders
-                        </div>
                     </div>
                 </div>
             </div>
@@ -135,7 +68,6 @@ Install Freenet and join the peer-to-peer network today!
         return substitute_html(content,
             md__slogan=slogan,
             md__mission=mission,
-            html__sliders=concat_html(sliders),
             str__download_text=download_text,
             md__donate_text=donate_text,
             str__donate_button_text=donate_button_text,


### PR DESCRIPTION
Based on PR https://github.com/freenet/website/pull/71
## Reasons for removal

The award was of 2014/2015, and we're at 2016 now.

Notice: The image file of the badge is not removed because the News page also uses it, see commit 0750c489b24b62e37528f56978c1a26b7fe68364.
## Screenshots
### Currently deployed old code

![website-old](https://cloud.githubusercontent.com/assets/78502/17466205/c5c0f138-5d0a-11e6-9da0-6335a89a9542.png)
### Base PR https://github.com/freenet/website/pull/71

![website-new1](https://cloud.githubusercontent.com/assets/78502/17466214/f0e57708-5d0a-11e6-8b54-49239ce1f29b.png)
### This PR

![website-new2](https://cloud.githubusercontent.com/assets/78502/17466360/9f4ac0f2-5d0e-11e6-99d1-c6ddbf31e469.png)
