### PR TITLE
download: add headless install instructions (-console)

### DIFF
--- a/pages/download.py
+++ b/pages/download.py
@@ -184,6 +184,10 @@ Open a terminal and run:
     wget 'https://freenetproject.org/assets/jnlp/freenet_installer.jar' -O new_installer_offline.jar
     java -jar new_installer_offline.jar
 """ + "\n\n" + _("""
+For a headless install use:
+""") + "\n\n" + """
+    java -jar new_installer_offline.jar -console
+""" + "\n\n" + _("""
 Alternatively, downloading [the installer](assets/jnlp/freenet_installer.jar)
 ([gpg signature][jar_sig]; [keyring][url_keyring])
 and then clicking on the file may work on some systems, but if there are


### PR DESCRIPTION
This adds two lines to show directly how to run the GNU/Linux installer in headless mode. People requested that "feature" multiple times, but we just did not document on the download-page that we had it all along.