### PR TITLE
prepare for 1476 (do not publish before wednesday)

### DIFF
--- a/pages/news.py
+++ b/pages/news.py
@@ -22,12 +22,19 @@ Freenet 0.7.5 build 1476 is now available.
 
 Highlights:
 
-- efficiency improvements: routing for fast nodes and spare bitmaps
-- a new gif filter with improved security
+- efficiency improvements, especially for fast nodes
+- a new gif filter with improved security against malicious files
+- show persistent update info alongside bookmarks
 - improved maintainability by replacing custom code with standard code
-- show update info alongside bookmarks
-- ssl fixes
 - update plugins: Sharesite 0.4.4, Library v37, Freereader 6
+
+Sharesite plugin highlights:
+
+- Provide default content
+- Mask the timezone
+- Allow setting the path
+
+Also Library and Freereader got bugfixes and cleanup.
 
 Thank you to all involved!
 

--- a/pages/news.py
+++ b/pages/news.py
@@ -16,6 +16,26 @@ class NewsItem(object):
 def news_items():
     donate_button = """<a class="btn button-custom btn-custom-two donate-button" href="donate.html">""" + _("Donate today.") + """</a>"""
     return [
+        NewsItem("20170301-1476", _("2017-03-01 - Freenet build 1476 released"),
+_("""
+Freenet 0.7.5 build 1476 is now available.
+
+Highlights:
+
+- efficiency improvements: routing for fast nodes and spare bitmaps
+- a new gif filter with improved security
+- improved maintainability by replacing custom code with standard code
+- show update info alongside bookmarks
+- ssl fixes
+- update plugins: Sharesite 0.4.4, Library v37, Freereader 6
+
+Thank you to all involved!
+
+For more details see the [announcement email][announcement1476].
+""") + """
+
+[announcement1476]: TODO!
+"""),
         NewsItem("20160625-1475", _("2016-06-25 - Freenet build 1475 released"),
 _("""
 (This news item was not published until July 16th. Sorry for the delay.)

--- a/pages/news.py
+++ b/pages/news.py
@@ -34,7 +34,7 @@ Thank you to all involved!
 For more details see the [announcement email][announcement1476].
 """) + """
 
-[announcement1476]: TODO!
+[announcement1476]: https://emu.freenetproject.org/pipermail/devl/2017-March/039591.html
 """),
         NewsItem("20160625-1475", _("2016-06-25 - Freenet build 1475 released"),
 _("""

--- a/pages/news.py
+++ b/pages/news.py
@@ -30,9 +30,9 @@ Highlights:
 
 Sharesite plugin highlights:
 
-- Provide default content
 - Mask the timezone
 - Allow setting the path
+- Provide default content
 
 Also Library and Freereader got bugfixes and cleanup.
 


### PR DESCRIPTION
please do not publish this yet. As soon as the update is shown as working, we can turn this into a press release on monday and give the press a 3 day warning.

We could use something like "Freenet was updated to 1476, deployment of the update started 2016-03-01 over Freenet itself and most nodes now run the new version".