### PR TITLE
Fix license name

### DIFF
--- a/theme/templates/footer.html
+++ b/theme/templates/footer.html
@@ -15,5 +15,5 @@
 		<span>IRC: <a href="https://web.libera.chat/?nick=FollowRabbit|?#freenet">#freenet on irc.libera.chat</a></span></br>
 	</div>
 
-	<p id="copyright">Licensed under the <a href="https://www.gnu.org/licenses/fdl-1.3.html">GDFL</a>. <a href="https://github.com/hyphanet/website">Website source repository</a>, <a href="/pages/download.html#privacy-policy">Privacy Policy</a></p>
+	<p id="copyright">Licensed under the <a href="https://www.gnu.org/licenses/fdl-1.3.html">GFDL</a>. <a href="https://github.com/hyphanet/website">Website source repository</a>, <a href="/pages/download.html#privacy-policy">Privacy Policy</a></p>
 </footer>


### PR DESCRIPTION
The license name had a typo in it. Not much more to say. 😄 